### PR TITLE
Fixed Python 3 incompatibility

### DIFF
--- a/walrus/utils.py
+++ b/walrus/utils.py
@@ -1,4 +1,7 @@
-import itertools
+try:
+    from itertools import izip_longest
+except ImportError:
+    from itertools import zip_longest as izip_longest
 import os
 import sys
 
@@ -37,7 +40,7 @@ def load_stopwords(stopwords_file):
 _sentinel = object()
 
 def chunked(iterable, n):
-    gen_expr = (list(g) for g in itertools.izip_longest(
+    gen_expr = (list(g) for g in izip_longest(
         *[iter(iterable)] * n, fillvalue=_sentinel))
     for group in gen_expr:
         if group[-1] is _sentinel:


### PR DESCRIPTION
Fixed itertools.izip_longest (Python2) / itertools.zip_longest (Python3) incompatibility.
